### PR TITLE
Close channel specific devices (i.e. /dev/vmmc11, /dev/vmmc12, ...) w…

### DIFF
--- a/src/channels/chan_lantiq.c
+++ b/src/channels/chan_lantiq.c
@@ -1710,6 +1710,9 @@ static void lantiq_cleanup(void)
 		if (ioctl(dev_ctx.ch_fd[c], IFX_TAPI_DEC_STOP, 0)) {
 			ast_log(LOG_WARNING, "IFX_TAPI_DEC_STOP ioctl failed\n");
 		}
+
+		close(dev_ctx.ch_fd[c]);
+		dev_ctx.ch_fd[c] = -1;
 		led_off(dev_ctx.ch_led[c]);
 	}
 


### PR DESCRIPTION
…hen unloading module.

Signed-off-by: Arnold Schulz <arnysch@gmx.net>