### PR TITLE
Use ast_malloc and ast_free instead of malloc and free

### DIFF
--- a/src/channels/chan_lantiq.c
+++ b/src/channels/chan_lantiq.c
@@ -582,7 +582,7 @@ on_exit:
 	if (fd != NULL)
 		fclose(fd);
 
-	if (*ppBuf != NULL && status)
+	if (status)
 		ast_free(*ppBuf);
 
 	return status;
@@ -608,8 +608,7 @@ static int32_t lantiq_dev_firmware_download(int32_t fd, const char *path)
 		return -1;
 	}
 
-	if (firmware != NULL)
-		ast_free(firmware);
+	ast_free(firmware);
 
 	return 0;
 }

--- a/src/channels/chan_lantiq.c
+++ b/src/channels/chan_lantiq.c
@@ -563,9 +563,9 @@ lantiq_dev_binary_buffer_create(const char *path, uint8_t **ppBuf, uint32_t *pBu
 		goto on_exit;
 	}
 
-	*ppBuf = malloc(file_stat.st_size);
+	*ppBuf = ast_malloc(file_stat.st_size);
 	if (*ppBuf == NULL) {
-		ast_log(LOG_ERROR, "binary file %s memory allocation failed\n", path);
+		// Message already logged by ast_malloc
 		goto on_exit;
 	}
 
@@ -583,7 +583,7 @@ on_exit:
 		fclose(fd);
 
 	if (*ppBuf != NULL && status)
-		free(*ppBuf);
+		ast_free(*ppBuf);
 
 	return status;
 }
@@ -609,7 +609,7 @@ static int32_t lantiq_dev_firmware_download(int32_t fd, const char *path)
 	}
 
 	if (firmware != NULL)
-		free(firmware);
+		ast_free(firmware);
 
 	return 0;
 }


### PR DESCRIPTION
in order to get rid of build errors with asterisk16 in OpenWrt.
(asterisk16 has recently been included in the telefony repository)

Signed-off-by: arny <arnysch@gmx.net>